### PR TITLE
rust*: format and small fixes

### DIFF
--- a/rust01-hello-world/src/lib.rs
+++ b/rust01-hello-world/src/lib.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![no_std]
 
-use riot_wrappers::riot_main;
 use riot_wrappers::println;
+use riot_wrappers::riot_main;
 use riot_wrappers::ztimer::Clock;
 
 extern crate rust_riotmodules;
@@ -15,5 +15,8 @@ fn main() {
     Clock::sec().sleep_extended(core::time::Duration::from_secs(5));
 
     println!("Hello Rust!");
-    println!("You are running RIOT on a(n) {} board.\n", riot_wrappers::BOARD);
+    println!(
+        "You are running RIOT on a(n) {} board.\n",
+        riot_wrappers::BOARD
+    );
 }

--- a/rust02-timers/README.md
+++ b/rust02-timers/README.md
@@ -59,7 +59,7 @@ Add a new timer to turn LED1 on after 1 second.
 
 **1. Define LED 1:**
 ```rust
-let mut led1 = riot_wrappers::led::LED::<1>::new();
+let mut led1 = riot_wrappers::led::LED::<1>::new_checked().expect("Our board has an LED1");
 ```
 
 The `::<1>` is a generic argument:

--- a/rust02-timers/README.md
+++ b/rust02-timers/README.md
@@ -36,7 +36,18 @@ $ make all flash term
 **2. Reset the board. You should see "This is a timers example", and then a "Timeout!" string after 4 seconds.**
 
 ## Task 2
-Modify the application so that the board has the LED on for only 250 ms, and runs only 10 iterations.
+Modify the `blink` function so that the board has the LED on for only 250 ms, and runs only 10 iterations.
+
+```rust
+fn blink<const I: u8>(led: &mut LED<I>) {
+```
+The `<I>` on the `led: &mut LED<I>` parameter is a generic argument:
+The LED subsystem of RIOT is optimized for low latency to assist in debugging.
+By using a generic argument instead of a struct field (e.g, `struct LED { number: u8, ... }`),
+it is ensured that the LED number is already known at build time.
+
+The generic parameter `<I>` is propagated to the function signature `blink<const I: u8>` so that `blink` can be called
+not only for a specific LED, e.g. `LED<0>`, but for all LEDs.
 
 **1. Adapt the loop to be true for 10 iterations:**
 ```rust
@@ -62,25 +73,16 @@ Add a new timer to turn LED1 on after 1 second.
 let mut led1 = riot_wrappers::led::LED::<1>::new_checked().expect("Our board has an LED1");
 ```
 
-The `::<1>` is a generic argument:
-The LED subsystem of RIOT is optimized for low latency to assist in debugging,
-and the generic argument ensures that the number is known at build time.
+We substitute here the generic parameter on `LED<const u8: I>` with actual LED number `<1>`.
 
-**2. Around the loop, call the [`set_during`](https://rustdoc.etonomy.org/riot_wrappers/ztimer/struct.Clock.html#method.set_during) function, and in the callback, turn on LED1.**
+**2. Call the [`set_during`](https://rustdoc.etonomy.org/riot_wrappers/ztimer/struct.Clock.html#method.set_during) function, and in the callback, turn on LED1.**
 
 ```rust
 Clock::msec().set_during(
     || led1.on().unwrap(),
-    riot_wrappers::ztimer::Ticks::from_duration(
-        Duration::from_secs(1)
-        ).expect("1 second is expressible in millisecond ticks"),
-    || {
-```
-
-(existing `for` loop remains in here)
-
-```rust
-});
+    Duration::from_secs(1).try_into().unwrap(),
+    || blink(&mut led0), // thread function
+);
 ```
 
 The `||` indicates a [closure](https://doc.rust-lang.org/book/ch13-01-closures.html):
@@ -92,6 +94,9 @@ Note that the LED 1 was sent from the main thread to the interrupt handler defin
 Code that should execute inside an interrupt handler is limited
 (for example, no blocking operations should occur).
 The requirement that data sent to an interrupt handler is `Send` prevents many mistakes there.
+
+The second closure describes the main thread logic that should run while the interrupt has not been triggered yet.
+Here, we insert the old `blink` function.
 
 **3. Recompile and build the application. Press the reset button.**
 ```sh

--- a/rust02-timers/src/lib.rs
+++ b/rust02-timers/src/lib.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![no_std]
 
-use riot_wrappers::riot_main;
-use riot_wrappers::println;
-use riot_wrappers::ztimer::Clock;
 use core::time::Duration;
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+use riot_wrappers::ztimer::Clock;
 
 // We are using the LED through a generic "on"/"off" interface.
 use switch_hal::OutputSwitch;

--- a/rust02-timers/src/lib.rs
+++ b/rust02-timers/src/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 
 use core::time::Duration;
+use riot_wrappers::led::LED;
 use riot_wrappers::println;
 use riot_wrappers::riot_main;
 use riot_wrappers::ztimer::Clock;
@@ -13,6 +14,21 @@ use switch_hal::OutputSwitch;
 extern crate rust_riotmodules;
 
 riot_main!(main);
+
+// Blink accepts an LED with a generic ID.
+fn blink<const I: u8>(led: &mut LED<I>) {
+    for _ in 0..20 {
+        // This blinks the LED in a 50% duty cycle once per second
+
+        // Is "unwrap()" bad? No, we know that our LEDs do not fail.
+        // In future Rust versions we can express this even more clearly
+        // <https://github.com/rust-lang/rust/pull/122792>.
+        led.on().unwrap();
+        Clock::msec().sleep_extended(Duration::from_millis(500));
+        led.off().unwrap();
+        Clock::msec().sleep_extended(Duration::from_millis(500));
+    }
+}
 
 fn main() {
     // Startup delay to ensure the terminal is connected
@@ -30,18 +46,7 @@ fn main() {
 
     let mut led0 = riot_wrappers::led::LED::<0>::new_checked().expect("Our board has an LED0");
 
-
-    for _ in 0..20 {
-        // This blinks the LED in a 50% duty cycle once per second
-
-        // Is "unwrap()" bad? No, we know that our LEDs do not fail.
-        // In future Rust versions we can express this even more clearly
-        // <https://github.com/rust-lang/rust/pull/122792>.
-        led0.on().unwrap();
-        Clock::msec().sleep_extended(Duration::from_millis(500));
-        led0.off().unwrap();
-        Clock::msec().sleep_extended(Duration::from_millis(500));
-    }
+    blink(&mut led0);
 
     println!("Done!");
 }

--- a/rust03-shell/README.md
+++ b/rust03-shell/README.md
@@ -123,7 +123,7 @@ Modify the `toggle` command so it accepts as first argument `0` or `1`, and togg
 the specific LED (using `LED0_TOGGLE` or `LED1_TOGGLE`).
 
 **1. As the command now takes 1 argument, we need to adapt the initial check in the `toggle` function.**
-**Also, adapt the usage `printf` to indicate that an argument is required (`"usage: {} <led_number>"`).**
+**Also, adapt the usage `printf` to indicate that an argument is required (`"usage: {commandname} <led_number>"`).**
 
 ```rust
     let (Some(number), None) = (args.next(), args.next()) else {

--- a/rust03-shell/src/lib.rs
+++ b/rust03-shell/src/lib.rs
@@ -12,14 +12,12 @@ riot_main!(main);
 
 fn main() {
     use riot_wrappers::shell::CommandList;
-    riot_wrappers::shell::new()
-        .run_forever();
+    riot_wrappers::shell::new().run_forever();
 }
-
 
 riot_wrappers::static_command!(static_echo, "echo", "Echo message", echo);
 
-pub fn echo<'a>(w: &mut impl Write, args: impl IntoIterator<Item=&'a str>) {
+pub fn echo<'a>(w: &mut impl Write, args: impl IntoIterator<Item = &'a str>) {
     let mut args = args.into_iter();
     let commandname = args.next().expect("argv is always present");
 

--- a/rust04-saul/README.md
+++ b/rust04-saul/README.md
@@ -82,10 +82,10 @@ For more information about phydat, like units and provided functions, check the
 
 Modify the application to also read values from the onboard accelerometer.
 
-**1. Find the onboard accelerometer, by searching for a device of type `SAUL_SENSE_ACCEL` using `saul_reg_find_type`.**
+**1. Find the onboard accelerometer, by searching for the first device of type `SAUL_SENSE_ACCEL` using `saul_reg_find_type`.**
 ```rust
 let accel_sensor = RegistryEntry::all()
-    .filter(|e| matches!(e.type_(), Some(Class::Sensor(Some(SensorClass::Accel)))))
+    .find(|e| matches!(e.type_(), Some(Class::Sensor(Some(SensorClass::Accel)))))
     // ...
 ```
 

--- a/rust04-saul/src/lib.rs
+++ b/rust04-saul/src/lib.rs
@@ -22,8 +22,7 @@ fn main() {
     let mut led0 = riot_wrappers::led::LED::<0>::new_checked().expect("Our board has an LED0");
 
     let temp_sensor = RegistryEntry::all()
-        .filter(|e| matches!(e.type_(), Some(Class::Sensor(Some(SensorClass::Temp)))))
-        .next()
+        .find(|e| matches!(e.type_(), Some(Class::Sensor(Some(SensorClass::Temp)))))
         .expect("No temperature sensor present");
 
     println!(

--- a/rust04-saul/src/lib.rs
+++ b/rust04-saul/src/lib.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![no_std]
 
-use riot_wrappers::riot_main;
-use riot_wrappers::println;
-use riot_wrappers::ztimer::Clock;
 use core::time::Duration;
-use riot_wrappers::saul::{RegistryEntry, Class, SensorClass, Unit};
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+use riot_wrappers::saul::{Class, RegistryEntry, SensorClass, Unit};
+use riot_wrappers::ztimer::Clock;
 
 extern crate rust_riotmodules;
 
@@ -26,12 +26,13 @@ fn main() {
         .next()
         .expect("No temperature sensor present");
 
-    println!("Found temperature device: {}", temp_sensor.name().unwrap_or("(unnamed)"));
+    println!(
+        "Found temperature device: {}",
+        temp_sensor.name().unwrap_or("(unnamed)")
+    );
 
     loop {
-        let temperature = temp_sensor
-            .read()
-            .expect("Error reading temperature");
+        let temperature = temp_sensor.read().expect("Error reading temperature");
 
         println!("Read value: {:?}", temperature);
 

--- a/rust05-gpio/README.md
+++ b/rust05-gpio/README.md
@@ -1,7 +1,7 @@
 # GPIOs
 
 General Purpose Input/Outputs (GPIOs) are a peripheral that allows
-microcontrollers to interact with the physical world. They are 
+microcontrollers to interact with the physical world. They are
 commonly known as pins. As the name suggests, they can be either configured as
 digital inputs or digital outputs. That is, they can read a digital value from
 the outside, or present a digital value to the outside (which translates in
@@ -137,7 +137,7 @@ extern "C" fn button_callback(arg: *mut riot_sys::libc::c_void) {
 
     // On a regular input pin we could run `.is_low()`, but the `riot_wrappers::gpio::OutputGPIO`
     // type would reconfigure the pin in its constructor, so we even read it manually.
-    if unsafe { riot_sys::gpio_read(pins.button.to_c()) } == 0 {
+    if unsafe { !riot_sys::gpio_read(pins.button.to_c()) } {
         pins.led1.set_high();
     }
     else {

--- a/rust05-gpio/src/lib.rs
+++ b/rust05-gpio/src/lib.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![no_std]
 
-use riot_wrappers::riot_main;
-use riot_wrappers::println;
-use riot_wrappers::ztimer::Clock;
 use core::time::Duration;
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+use riot_wrappers::ztimer::Clock;
 
 // [TASK 1: Add convenience `use` line]
 
@@ -24,9 +24,9 @@ fn main() {
     println!("GPIOs example.");
 
     // [TASK 1: Initialize led0 here]
-    
+
     // [TASK 2: Initialize led1 and button here]
-    
+
     // [TASK 1: Loop here]
 }
 


### PR DESCRIPTION
Few minor things that I noticed while doing the tutorial.

The only "controversial" change might be 11878f7679223fc30feffa9e287c08a296f403c2, which simplifies the parameter for `set_during` in `rust02-timers`. 
`blink` doesn't necessarily needs to be a separate function (we could also just define the closure before calling `set_during`), but IMO having the whole closure inside the function call makes the code quite hard to understand.
